### PR TITLE
fix: use virtool/workflow:1.0.0 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-FROM virtool/workflow:nightly
-
+FROM virtool/workflow:1.0.0
 WORKDIR /workflow
-
 COPY workflow.py /workflow/workflow.py


### PR DESCRIPTION
Stop using nightly build which is no longer published or current.