### PR TITLE
Update virtool-workflow image to 1.0.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM virtool/workflow:1.0.3
+FROM virtool/workflow:1.0.4
 
 WORKDIR /workflow
 COPY workflow.py /workflow/workflow.py


### PR DESCRIPTION
Resolves mismatch between package and Docker image.